### PR TITLE
Handle optional packs in scenario orchestrator

### DIFF
--- a/configs/scenarios/pd_only.yaml
+++ b/configs/scenarios/pd_only.yaml
@@ -1,0 +1,9 @@
+name: pd_only
+channels: 4
+trials: 5
+emitter_pack: configs/packs/emitter_typ.yaml
+optics_pack: configs/packs/optics_typ.yaml
+sensor_pack: configs/packs/sensor_typ.yaml
+tia_pack: configs/packs/tia_typ.yaml
+comparator_pack: configs/packs/comparator_typ.yaml
+clock_pack: configs/packs/clock_typ.yaml

--- a/tests/test_scenario_optional_packs.py
+++ b/tests/test_scenario_optional_packs.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+import sys
+
+repo_root = Path(__file__).resolve().parent.parent
+if str(repo_root) not in sys.path:
+    sys.path.insert(0, str(repo_root))
+
+from looking_glass.scenario import build_orchestrator_from_scenario
+
+
+def test_build_orchestrator_without_optional_packs():
+    scenario_path = repo_root / "configs" / "scenarios" / "pd_only.yaml"
+
+    orch, trials, scn = build_orchestrator_from_scenario(scenario_path)
+
+    assert trials == 5
+    assert "camera_pack" not in scn
+    assert "thermal_pack" not in scn
+
+    # Optional packs should not be instantiated when missing from the scenario
+    assert orch.cam is None
+    assert orch.therm is None
+
+    # A single step should execute without raising even without optional packs
+    result = orch.step()
+    assert "ber" in result
+    assert "energy_pj" in result


### PR DESCRIPTION
## Summary
- skip loading optional pack descriptors before invoking the YAML loader so missing entries are treated as absent
- allow orchestrator construction when camera/thermal packs are omitted by guarding instantiation and returning `None`
- add a PD-only scenario plus a regression test that exercises the CLI helper without optional packs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb9e04e23c832395eb22715bbc2682